### PR TITLE
Allow simple context to access fields

### DIFF
--- a/src/contexts/simple.zig
+++ b/src/contexts/simple.zig
@@ -84,7 +84,7 @@ pub fn Simple(comptime SubCtx: type) type {
                     return Ns.EvalProperty(Lhs, field);
                 }
             }
-            return std.meta.FieldType(Lhs, field);
+            return @FieldType(Lhs, field);
         }
         pub inline fn evalProperty(ctx: Self, lhs: anytype, comptime field: []const u8) !EvalProperty(@TypeOf(lhs), field) {
             const Lhs = @TypeOf(lhs);
@@ -257,7 +257,6 @@ pub fn Simple(comptime SubCtx: type) type {
             const func = @field(util.ImplicitDeref(@TypeOf(self_param)), method);
             return ctx.evalFuncCall(func, .{self_param} ++ args);
         }
-
     };
 }
 
@@ -310,4 +309,22 @@ test simple {
         }
     }{});
     try std.testing.expectEqual(2, comath.eval("(++2 ^ 5) $ 36", op_override_ctx, .{}));
+}
+
+test "field access" {
+    const Vec = struct {
+        x: f32,
+        y: f32,
+    };
+
+    const v: Vec = .{ .x = 1, .y = 2 };
+
+    try std.testing.expectEqual(
+        1,
+        comath.eval("v.x", simple({}), .{ .v = v }),
+    );
+    try std.testing.expectEqual(
+        2,
+        comath.eval("v.y", simple({}), .{ .v = v }),
+    );
 }


### PR DESCRIPTION
Fix #11 

Switch from `std.meta.FieldType` to `@FieldType` to re-enable field access from the Simple context, add a unit test.

Doc string for `std.meta.FieldType` notes that its deprecated and suggests use of `@FieldType`:

https://github.com/ziglang/zig/blob/fc2c1883b36a6ba8c7303d12b57147656dc7dd70/lib/std/meta.zig#L421